### PR TITLE
Added checks to make sure users are logged into Claude Code before using integration and clarified README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,17 @@ Ask Claude questions about findings without leaving the TUI. Powered by the `cla
 
 **Setup:**
 ```bash
-# Install Claude Code CLI (required)
+# Install Claude Code CLI and authenticate (required)
 npm install -g @anthropic-ai/claude-code   # or follow https://claude.ai/code
+claude  # launches interactive setup — complete login before using this feature
 
 # Disable if not wanted
 cerno config set claude_assistant_enabled false
 ```
 
-**Tool availability:** `[A]` is hidden when `claude` is not on PATH or `claude_assistant_enabled` is `false`. It appears in the tool availability table on review startup alongside nmap/netexec/msfconsole.
+**Tool availability:** `[A]` is hidden when `claude` is not on PATH, you are not logged into Claude Code, or `claude_assistant_enabled` is `false`. It appears in the tool availability table on review startup alongside nmap/netexec/msfconsole.
 
-> **Note:** This feature is in beta. Responses may be inaccurate — always verify before acting on suggestions.
+> **Note:** This feature is in beta and requires an active Claude Code session on your machine. Responses may be inaccurate — always verify before acting on suggestions.
 
 ---
 

--- a/cerno_pkg/claude_assistant.py
+++ b/cerno_pkg/claude_assistant.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -65,16 +66,27 @@ _claude_available: bool | None = None
 
 
 def check_claude_available() -> bool:
-    """Return True if the 'claude' CLI is on PATH.
-
+    """Return True if the 'claude' CLI is on PATH and the user is logged in.
     Result is cached for the lifetime of the process.
-
     Returns:
-        True if claude binary is found, False otherwise
+        True if claude binary is found and user is logged in, False otherwise
     """
     global _claude_available
     if _claude_available is None:
-        _claude_available = shutil.which("claude") is not None
+        if shutil.which("claude") is None:
+            _claude_available = False
+        else:
+            try:
+                result = subprocess.run(
+                    ["claude", "auth", "status"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                status = json.loads(result.stdout)
+                _claude_available = status.get("loggedIn", False)
+            except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+                _claude_available = False
     return _claude_available
 
 

--- a/cerno_pkg/render.py
+++ b/cerno_pkg/render.py
@@ -1169,7 +1169,9 @@ def render_tool_availability_table(include_unavailable: bool = True) -> None:
         table.add_row("proxychains4", "✅" if pc4_available else "❌", pc4_details_text)
 
     # Claude Code (assistant — not a workflow tool, so not in the registry)
-    claude_available = bool(shutil.which("claude"))
+    from cerno_pkg.claude_assistant import check_claude_available
+    _claude_config = load_config()
+    claude_available = check_claude_available() and _claude_config.claude_assistant_enabled
     if include_unavailable or claude_available:
         if claude_available:
             claude_version = get_tool_version("claude")


### PR DESCRIPTION
Updated code to check if the user is logged into Claude Code by running `claude auth status` on startup, and updated rendering code to use the same check before displaying tool availability. The program will now show that claude is "Not found in PATH" if the user has it installed, but is not logged in. Updated README to clarify that users need to log into Claude Code before using the integration in Cerno.